### PR TITLE
chore(db-dependency): increase maximum number of connections

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -606,6 +606,9 @@ postgresql:
           secretKeyRef:
             name: "{{ .Values.auth.existingSecret }}"
             key: "provisioning-password"
+  readReplicas:
+    extendedConfiguration: |
+      max_connections = 200
 
 
 externalDatabase:


### PR DESCRIPTION
## Description

increase maximum number of connections for database dependency

## Why

default max_conn is 100
increase to 200 to avoid running out of slots, which was observed at upgrade

## Issue

n/a
ref: CPLP-2739

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
