### PR TITLE
chore(trg-helm): add helm test workflow update to main

### DIFF
--- a/.github/workflows/portal-chart-test.yaml
+++ b/.github/workflows/portal-chart-test.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-          helm install portal --version ${{ github.event.inputs.upgrade_from }} tractusx-dev/portal
+          helm install portal tractusx-dev/portal --version ${{ github.event.inputs.upgrade_from }}
           helm dependency update charts/portal
           helm upgrade portal charts/portal
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
## Description

add helm test workflow update to main

## Why

ad hoc update to main needed because default values aren't available in fork (where main is the default branch):
https://github.com/eclipse-tractusx/portal-cd/actions/runs/5133753219/jobs/9236787382#step:10:4

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
