### PR TITLE
fix: added serviceAccountClientPrefix for process

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -80,6 +80,8 @@ spec:
             - name: "CONNECTIONSTRINGS__PROVISIONINGDB"
               value: "Server={{ .Values.externalDatabase.host }};Database={{ .Values.externalDatabase.database }};Port={{ .Values.externalDatabase.port }};User Id={{ .Values.externalDatabase.provisioningUser }};Password=$(PROVISIONING_PASSWORD);Ssl Mode={{ .Values.backend.dbConnection.sslMode }};"
             {{- end }}
+            - name: "PROVISIONING__SERVICEACCOUNTCLIENTPREFIX"
+              value: "{{ .Values.backend.provisioning.serviceAccountClientPrefix }}"
             - name: "APPLICATIONACTIVATION__APPLICATIONAPPROVALINITIALROLES__0__CLIENTID"
               value: "{{ .Values.centralidp.clients.portal }}"
             - name: "APPLICATIONACTIVATION__APPLICATIONAPPROVALINITIALROLES__0__USERROLENAMES__0"


### PR DESCRIPTION
## Description

added serviceAccountClientPrefix for process

## Why

added serviceAccountClientPrefix for process to append the value for invitation process worker

## Issue

Ref: #579

[Link to pull request from other repository.](https://github.com/eclipse-tractusx/portal-backend/pull/608)

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
