### PR TITLE
feat(didResolver): add configuration for did resolver

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -268,6 +268,13 @@ spec:
               value: "{{ .Values.backend.processesworker.issuerComponent.encryptionConfigs.index0.cipherMode }}"
             - name: "APPLICATIONCHECKLIST__ISSUERCOMPONENT__ENCRYPTIONCONFIGS__0__PADDINGMODE"
               value: "{{ .Values.backend.processesworker.issuerComponent.encryptionConfigs.index0.paddingMode }}"
+            - name: "APPLICATIONCHECKLIST__BPNDIDRESOLVER__BASEADDRESS"
+              value: "{{ .Values.bpnDidResolverAddress }}"
+            - name: "APPLICATIONCHECKLIST__BPNDIDRESOLVER__APIKEY"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.backend.interfaces.secret }}"
+                  key: "bpndidresolver-api-key"
             - name: "KEYCLOAK__CENTRAL__AUTHREALM"
               value: "{{ .Values.centralidp.realm }}"
             - name: "KEYCLOAK__CENTRAL__CLIENTID"

--- a/charts/portal/templates/secret-backend-interfaces.yaml
+++ b/charts/portal/templates/secret-backend-interfaces.yaml
@@ -45,6 +45,7 @@ data:
   mailing-encryption-key0: {{ coalesce ( .Values.backend.processesworker.mailing.encryptionConfigs.index0.encryptionKey | b64enc ) ( index $secret.data "mailing-encryption-key0" ) | default ( randAlphaNum 32 ) | quote }}
   issuercomponent-client-secret: {{ coalesce ( .Values.backend.processesworker.issuerComponent.clientSecret | b64enc ) ( index $secret.data "issuercomponent-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
   issuercomponent-encryption-key0: {{ coalesce ( .Values.backend.processesworker.issuerComponent.encryptionConfigs.index0.encryptionKey | b64enc ) ( index $secret.data "issuercomponent-encryption-key0" ) | default ( randAlphaNum 32 ) | quote }}
+  bpndidresolver-api-key: {{ coalesce ( .Values.backend.processesworker.bpnDidResolver.apiKey | b64enc ) ( index $secret.data "bpndidresolver-api-kye" ) | default ( randAlphaNum 32 ) | quote }}
 {{ else -}}
 stringData:
   # if secret doesn't exist, use provided value from values file or generate a random one
@@ -61,4 +62,5 @@ stringData:
   mailing-encryption-key0: {{ .Values.backend.processesworker.mailing.encryptionConfigs.index0.encryptionKey | default ( randAlphaNum 32 ) | quote }}
   issuercomponent-client-secret: {{ .Values.backend.processesworker.issuerComponent.clientSecret | default ( randAlphaNum 32 ) | quote }}
   issuercomponent-encryption-key0: {{ .Values.backend.processesworker.issuerComponent.encryptionConfigs.index0.encryptionKey | default ( randAlphaNum 32 ) | quote }}
+  bpndidresolver-api-key: {{ .Values.backend.processesworker.bpnDidResolver.apiKey | default ( randAlphaNum 32 ) | quote }}
 {{ end }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -59,6 +59,8 @@ clearinghouseAddress: "https://validation.example.org"
 clearinghouseTokenAddress: "https://keycloak.example.org/realms/example/protocol/openid-connect/token"
 # -- Provide issuer component base address
 issuerComponentAddress: "https://issuercomponent.example.org"
+# -- Base address of the Bpn Did Resolver
+bpnDidResolverAddress: http://bpndidresolver.example.org/
 
 frontend:
   ingress:
@@ -872,6 +874,9 @@ backend:
           # -- EncryptionKey for the issuer component. Secret-key 'issuercomponent-encryption-key0'.
           # Expected format is 256 bit (64 digits) hex.
           encryptionKey: ""
+    bpnDidResolver:
+      # -- ApiKey for bpnDidResolver. Secret-key 'bpndidresolver-api-key'.
+      apiKey: ""
     invitation:
       invitedUserInitialRoles:
         role0: "Company Admin"

--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -253,6 +253,8 @@ backend:
       encryptionConfigs:
         index0:
           encryptionKey: "<path:portal/data/beta/processes-worker#issuercomponent-encryption-key0>"
+    bpnDidResolver:
+      clientSecret: "<path:portal/data/beta/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -30,6 +30,7 @@ sdfactoryAddress: "https://sdfactory.dev.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
 issuerComponentAddress: "https://ssi-credential-issuer.dev.demo.catena-x.net"
+bpnDidResolverAddress: "http://bpn-did-resolution-service-bdrs-server-memory:8081/api/management"
 
 frontend:
 
@@ -255,6 +256,8 @@ backend:
       encryptionConfigs:
         index0:
           encryptionKey: "<path:portal/data/dev/processes-worker#issuercomponent-encryption-key0>"
+    bpnDidResolver:
+      clientSecret: "<path:portal/data/dev/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -30,6 +30,7 @@ sdfactoryAddress: "https://sdfactory.int.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
 issuerComponentAddress: "https://ssi-credential-issuer.int.demo.catena-x.net"
+bpnDidResolverAddress: "http://bpn-did-resolution-service-bdrs-server-memory:8081/api/management"
 
 frontend:
 
@@ -253,6 +254,8 @@ backend:
       encryptionConfigs:
         index0:
           encryptionKey: "<path:portal/data/int/processes-worker#issuercomponent-encryption-key0>"
+    bpnDidResolver:
+      clientSecret: "<path:portal/data/int/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -30,6 +30,7 @@ sdfactoryAddress: "https://sdfactory-pen.dev.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
 issuerComponentAddress: "https://ssi-credential-issuer-pen.dev.demo.catena-x.net"
+bpnDidResolverAddress: "http://bpn-did-resolution-service-bdrs-server-memory:8081/api/management"
 
 frontend:
 
@@ -254,6 +255,8 @@ backend:
       encryptionConfigs:
         index0:
           encryptionKey: "<path:portal/data/pen/processes-worker#issuercomponent-encryption-key0>"
+    bpnDidResolver:
+      clientSecret: "<path:portal/data/pen/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -30,6 +30,7 @@ sdfactoryAddress: "https://sdfactory.dev.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
 issuerComponentAddress: "https://ssi-credential-issuer-rc.dev.demo.catena-x.net"
+bpnDidResolverAddress: "http://bpn-did-resolution-service-bdrs-server-memory:8081/api/management"
 
 frontend:
 
@@ -253,6 +254,8 @@ backend:
       encryptionConfigs:
         index0:
           encryptionKey: "<path:portal/data/dev/processes-worker#issuercomponent-encryption-key0>"
+    bpnDidResolver:
+      clientSecret: "<path:portal/data/dev/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:


### PR DESCRIPTION
## Description

Added configuration for the bpn did resolver

## Why

To enable the bpn did resolver for the portal backend

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/572

## Corresponding Backend PR

[#621](https://github.com/eclipse-tractusx/portal-backend/pull/621)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
