### PR TITLE
fix(ssi): adjust ssiCredentialIssuer address

### DIFF
--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -32,7 +32,7 @@ custodianAddress: "https://managed-identity-wallets-new.beta.demo.catena-x.net"
 sdfactoryAddress: "https://sdfactory.beta.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
-issuerComponentAddress: "https://ssi-credential-issuer.beta.demo.catena-x.net"
+issuerComponentAddress: "https://ssi-credential-issuer-backend.beta.demo.catena-x.net"
 dimWrapper:
   baseAddress: "https://dim.beta.demo.catena-x.net"
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -32,7 +32,7 @@ custodianAddress: "https://managed-identity-wallets-new.dev.demo.catena-x.net"
 sdfactoryAddress: "https://sdfactory.dev.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
-issuerComponentAddress: "https://ssi-credential-issuer.dev.demo.catena-x.net"
+issuerComponentAddress: "https://ssi-credential-issuer-backend.dev.demo.catena-x.net"
 bpnDidResolverAddress: "http://bdrs-bdrs-server:8081/api/management"
 dimWrapper:
   baseAddress: "https://dim.dev.demo.catena-x.net"

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -32,7 +32,7 @@ custodianAddress: "https://managed-identity-wallets-new.int.demo.catena-x.net"
 sdfactoryAddress: "https://sdfactory.int.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
-issuerComponentAddress: "https://ssi-credential-issuer.int.demo.catena-x.net"
+issuerComponentAddress: "https://ssi-credential-issuer-backend.int.demo.catena-x.net"
 bpnDidResolverAddress: "http://bdrs-bdrs-server:8081/api/management"
 dimWrapper:
   baseAddress: "https://dim.int.demo.catena-x.net"

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -32,7 +32,7 @@ custodianAddress: "https://managed-identity-wallets-pen-new.dev.demo.catena-x.ne
 sdfactoryAddress: "https://sdfactory-pen.dev.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
-issuerComponentAddress: "https://ssi-credential-issuer-pen.dev.demo.catena-x.net"
+issuerComponentAddress: "https://ssi-credential-issuer-backend-pen.dev.demo.catena-x.net"
 bpnDidResolverAddress: "http://bdrs-bdrs-server:8081/api/management"
 dimWrapper:
   baseAddress: "https://dim-pen.beta.demo.catena-x.net"

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -32,7 +32,7 @@ custodianAddress: "https://managed-identity-wallets-new.dev.demo.catena-x.net"
 sdfactoryAddress: "https://sdfactory.dev.demo.catena-x.net"
 clearinghouseAddress: "https://validation.test.dih-cloud.com"
 clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
-issuerComponentAddress: "https://ssi-credential-issuer-rc.dev.demo.catena-x.net"
+issuerComponentAddress: "https://ssi-credential-issuer-backend-rc.dev.demo.catena-x.net"
 bpnDidResolverAddress: "http://bdrs-bdrs-server:8081/api/management"
 dimWrapper:
   baseAddress: "https://dim-rc.dev.demo.catena-x.net"


### PR DESCRIPTION
## Description

adjust ssiCredentialIssuer address

## Why

The url of the ssi credential issuer component was configured wrongly

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
