### PR TITLE
fix(bpnDidResolver): set correct config for apiKey

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -897,7 +897,7 @@ backend:
           # Expected format is 256 bit (64 digits) hex.
           encryptionKey: ""
     bpnDidResolver:
-      # -- ApiKey for bpnDidResolver. Secret-key 'bpndidresolver-api-key'.
+      # -- ApiKey management endpoint of the bpnDidResolver. Secret-key 'bpndidresolver-api-key'.
       apiKey: ""
     invitation:
       invitedUserInitialRoles:

--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -264,7 +264,7 @@ backend:
         index0:
           encryptionKey: "<path:portal/data/beta/processes-worker#issuercomponent-encryption-key0>"
     bpnDidResolver:
-      clientSecret: "<path:portal/data/beta/processes-worker#bpndidresolver-api-key>"
+      apiKey: "<path:portal/data/beta/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -267,7 +267,7 @@ backend:
         index0:
           encryptionKey: "<path:portal/data/dev/processes-worker#issuercomponent-encryption-key0>"
     bpnDidResolver:
-      clientSecret: "<path:portal/data/dev/processes-worker#bpndidresolver-api-key>"
+      apiKey: "<path:portal/data/dev/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -267,7 +267,7 @@ backend:
         index0:
           encryptionKey: "<path:portal/data/int/processes-worker#issuercomponent-encryption-key0>"
     bpnDidResolver:
-      clientSecret: "<path:portal/data/int/processes-worker#bpndidresolver-api-key>"
+      apiKey: "<path:portal/data/int/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -266,7 +266,7 @@ backend:
         index0:
           encryptionKey: "<path:portal/data/pen/processes-worker#issuercomponent-encryption-key0>"
     bpnDidResolver:
-      clientSecret: "<path:portal/data/pen/processes-worker#bpndidresolver-api-key>"
+      apiKey: "<path:portal/data/pen/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -267,7 +267,7 @@ backend:
         index0:
           encryptionKey: "<path:portal/data/dev/processes-worker#issuercomponent-encryption-key0>"
     bpnDidResolver:
-      clientSecret: "<path:portal/data/dev/processes-worker#bpndidresolver-api-key>"
+      apiKey: "<path:portal/data/dev/processes-worker#bpndidresolver-api-key>"
     invitation:
       encryptionConfigs:
         index0:


### PR DESCRIPTION
## Description

Setting the correct configuration for the apiKey of the bpnDidResolver for the environments

## Why

To set the correct api key for the bpn did resolver

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
