### PR TITLE
fix: adjust clientId for dimcreationroles

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -391,7 +391,7 @@ spec:
             - name: "OFFERSUBSCRIPTIONPROCESS__ITADMINROLES__0__USERROLENAMES__0"
               value: "{{ .Values.backend.processesworker.offerSubscriptionProcess.itAdminRoles.role0 }}"
             - name: "OFFERSUBSCRIPTIONPROCESS__DIMCREATIONROLES__0__CLIENTID"
-              value: "{{ .Values.centralidp.clients.portal }}"
+              value: "{{ .Values.centralidp.clients.technicalRolesManagement }}"
             - name: "OFFERSUBSCRIPTIONPROCESS__DIMCREATIONROLES__0__USERROLENAMES__0"
               value: "{{ .Values.backend.administration.serviceAccount.dimCreationRoles.role0 }}"
             - name: "OFFERPROVIDER__SERVICEMANAGERROLES__0__CLIENTID"

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -446,7 +446,7 @@ spec:
         - name: "SERVICEACCOUNT__ENCRYPTIONCONFIGS__0__PADDINGMODE"
           value: "{{ .Values.backend.administration.serviceAccount.encryptionConfigs.index0.paddingMode }}"
         - name: "SERVICEACCOUNT__DIMCREATIONROLES__0__CLIENTID"
-          value: "{{ .Values.centralidp.clients.portal }}"
+          value: "{{ .Values.centralidp.clients.technicalRolesManagement }}"
         - name: "SERVICEACCOUNT__DIMCREATIONROLES__0__USERROLENAMES__0"
           value: "{{ .Values.backend.administration.serviceAccount.dimCreationRoles.role0 }}"
         - name: "SWAGGERENABLED"


### PR DESCRIPTION
## Description

Set the correct client id for the dim creation roles

## Why

Currently the dim technical user don't get created due to the wrong clientId

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
