### PR TITLE
fix(bdrs): adjust bdrs management url

### DIFF
--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -37,6 +37,7 @@ dimWrapper:
   baseAddress: "https://dim.beta.demo.catena-x.net"
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"
 bpnDidResolver:
+  managementApiAddress: "http://bdrs-bdrs-server:8081"
   directoryApiAddress: "https://bpn-did-resolution-service.beta.demo.catena-x.net/api/directory"
 
 frontend:

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -38,6 +38,7 @@ dimWrapper:
   baseAddress: "https://dim.dev.demo.catena-x.net"
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"
 bpnDidResolver:
+  managementApiAddress: "http://bdrs-bdrs-server:8081"
   directoryApiAddress: "https://bpn-did-resolution-service.dev.demo.catena-x.net/api/directory"
 
 frontend:

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -38,6 +38,7 @@ dimWrapper:
   baseAddress: "https://dim.int.demo.catena-x.net"
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"
 bpnDidResolver:
+  managementApiAddress: "http://bdrs-bdrs-server:8081"
   directoryApiAddress: "https://bpn-did-resolution-service.int.demo.catena-x.net/api/directory"
 
 frontend:

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -38,6 +38,7 @@ dimWrapper:
   baseAddress: "https://dim-pen.dev.demo.catena-x.net"
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"
 bpnDidResolver:
+  managementApiAddress: "http://bdrs-bdrs-server:8081"
   directoryApiAddress: "https://bpn-did-resolution-service-pen.dev.demo.catena-x.net/api/directory"
 
 frontend:

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -38,6 +38,7 @@ dimWrapper:
   baseAddress: "https://dim-rc.dev.demo.catena-x.net"
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"
 bpnDidResolver:
+  managementApiAddress: "http://bdrs-bdrs-server:8081"
   directoryApiAddress: "https://bpn-did-resolution-service-rc.dev.demo.catena-x.net/api/directory"
 
 frontend:


### PR DESCRIPTION
## Description

Add consortia specific bdrs management url

## Why

The bdrs push to the management api fails because the generic url isn't overwritten.

## Issue

Refs: [#721](https://github.com/eclipse-tractusx/portal-backend/issues/721)

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
