### PR TITLE
fix(decline): add decline url for invite process

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -451,6 +451,8 @@ spec:
               value: "{{ .Values.portalAddress }}{{ .Values.backend.registration.portalRegistrationPath }}"
             - name: "INVITATION__PASSWORDRESENDADDRESS"
               value: "{{ .Values.portalAddress }}{{ .Values.backend.portalPasswordResendPath }}"
+            - name: "INVITATION__CLOSEAPPLICATIONADDRESS"
+              value: "{{ .Values.portalAddress }}{{ .Values.backend.processesworker.invitation.closeApplicationPath }}"
             - name: "INVITATION__INITIALLOGINTHEME"
               value: "{{ .Values.backend.processesworker.invitation.initialLoginTheme }}"
             - name: "INVITATION__ENCRYPTIONCONFIGINDEX"


### PR DESCRIPTION
## Description

add decline url configuration for invitation process

## Why

The backend needs the configuration to set the correct decline url for the invitation mail template

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/701

## Corresponding Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/727

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
