### PR TITLE
fix(processWorker): add dimUserRoles to process config

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -82,6 +82,10 @@ spec:
             {{- end }}
             - name: "PROVISIONING__SERVICEACCOUNTCLIENTPREFIX"
               value: "{{ .Values.backend.provisioning.serviceAccountClientPrefix }}"
+            - name: "PROVISIONING__DIMUSERROLES__0__CLIENTID"
+              value: "{{ .Values.centralidp.clients.technicalRolesManagement }}"
+            - name: "PROVISIONING__DIMUSERROLES__0__USERROLENAMES__0"
+              value: "{{ .Values.backend.administration.serviceAccount.dimCreationRoles.role0 }}"
             - name: "APPLICATIONACTIVATION__APPLICATIONAPPROVALINITIALROLES__0__CLIENTID"
               value: "{{ .Values.centralidp.clients.portal }}"
             - name: "APPLICATIONACTIVATION__APPLICATIONAPPROVALINITIALROLES__0__USERROLENAMES__0"


### PR DESCRIPTION
## Description

added dim user roles to process worker config

## Why

The process worker currently don't start up

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
