### PR TITLE
feat(keycloak): add parameter clockSkew to jwtBearerOptions

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -332,6 +332,8 @@ spec:
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validAudiencePortal }}"
         - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__VALIDISSUER"
           value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validIssuerPath }}"
+        - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__CLOCKSKEW"
+          value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.clockSkew }}"
         - name: "JWTBEAREROPTIONS__REFRESHINTERVAL"
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.refreshInterval }}"
         - name: "KEYCLOAK__CENTRAL__AUTHREALM"

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -271,6 +271,8 @@ spec:
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validAudiencePortal }}"
         - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__VALIDISSUER"
           value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validIssuerPath }}"
+        - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__CLOCKSKEW"
+          value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.clockSkew }}"
         - name: "JWTBEAREROPTIONS__REFRESHINTERVAL"
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.refreshInterval }}"
         - name: "KEYCLOAK__CENTRAL__AUTHREALM"

--- a/charts/portal/templates/deployment-backend-notification.yaml
+++ b/charts/portal/templates/deployment-backend-notification.yaml
@@ -105,6 +105,8 @@ spec:
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validAudiencePortal }}"
         - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__VALIDISSUER"
           value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validIssuerPath }}"
+        - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__CLOCKSKEW"
+          value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.clockSkew }}"
         - name: "JWTBEAREROPTIONS__REFRESHINTERVAL"
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.refreshInterval }}"
         - name: "KEYCLOAK__CENTRAL__AUTHREALM"

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -107,6 +107,8 @@ spec:
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validAudienceRegistration }}"
         - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__VALIDISSUER"
           value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validIssuerPath }}"
+        - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__CLOCKSKEW"
+          value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.clockSkew }}"
         - name: "JWTBEAREROPTIONS__REFRESHINTERVAL"
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.refreshInterval }}"
         - name: "KEYCLOAK__CENTRAL__AUTHREALM"

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -103,6 +103,8 @@ spec:
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validAudiencePortal }}"
         - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__VALIDISSUER"
           value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.validIssuerPath }}"
+        - name: "JWTBEAREROPTIONS__TOKENVALIDATIONPARAMETERS__CLOCKSKEW"
+          value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.tokenValidationParameters.clockSkew }}"
         - name: "JWTBEAREROPTIONS__REFRESHINTERVAL"
           value: "{{ .Values.backend.keycloak.central.jwtBearerOptions.refreshInterval }}"
         - name: "KEYCLOAK__CENTRAL__AUTHREALM"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -249,6 +249,7 @@ backend:
           validIssuerPath: "/auth/realms/CX-Central"
           validAudiencePortal: "Cl2-CX-Portal"
           validAudienceRegistration: "Cl1-CX-Registration"
+          clockSkew: "00:05:00"
         refreshInterval: "00:00:30"
       tokenPath: "/auth/realms/CX-Central/protocol/openid-connect/token"
       dbConnection:


### PR DESCRIPTION
## Description

Parameter validateLifetime has been added to the configuration of backendservices to enable expiration-check of keycloak-tokens.

## Why

without this configuration the backendservices accept expired tokens from keycloak. This is a security-issue.

## Issue

https://github.com/eclipse-tractusx/portal-backend/issues/586

Link to pull request from other repository.
N/A

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my changes