### PR TITLE
feat(portalmigrations): enable seeding of test data with configmap

### DIFF
--- a/charts/portal/templates/job-backend-portal-migrations.yaml
+++ b/charts/portal/templates/job-backend-portal-migrations.yaml
@@ -69,14 +69,30 @@ spec:
           - name: "SEEDING__TESTDATAENVIRONMENTS__0"
             value: "{{ .Values.backend.portalmigrations.seeding.testDataEnvironments }}"
           - name: "SEEDING__DATAPATHS__0"
-            value: "{{ .Values.backend.portalmigrations.seeding.testDataPaths }}"
+            value: "Seeder/Data"
           - name: "SERILOG__MINIMUMLEVEL__Default"
             value: "{{ .Values.backend.portalmigrations.logging.default }}"
           - name: "PROCESSIDENTITY__PROCESSUSERID"
-            value: "{{ .Values.backend.portalmigrations.processIdentity.processUserId }}"
+            value: "d21d2e8a-fe35-483c-b2b8-4100ed7f0953"
+          {{- if and (.Values.backend.portalmigrations.seeding.testData.configMap) (.Values.backend.portalmigrations.seeding.testData.filename) }}
+          - name: "SEEDING__DATAPATHS__1"
+            value: "Seeder/Data/import"
+          - name: "SEEDING__TESTDATAENVIRONMENTS__1"
+            value: "{{ .Values.backend.portalmigrations.seeding.testData.filename }}"
+          {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.portContainer }}
           protocol: TCP
         resources:
           {{- toYaml .Values.backend.portalmigrations.resources | nindent 10 }}
+      {{- if and (.Values.backend.portalmigrations.seeding.testData.configMap) (.Values.backend.portalmigrations.seeding.testData.filename) }}
+        volumeMounts:
+          - name: test-data
+            mountPath: /migrations/Seeder/Data/import
+      volumes:
+        - name: test-data
+          configMap:
+            name: "{{ .Values.backend.portalmigrations.seeding.testData.configMap }}"
+            optional: true
+      {{- end }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -610,11 +610,12 @@ backend:
         memory: 350M
     seeding:
       testDataEnvironments: ""
-      # -- when changing the testDataPath the processIdentity needs to be adjusted as well,
-      # or it must be ensured that the identity is existing within the files under the new path
-      testDataPaths: "Seeder/Data"
-    processIdentity:
-      processUserId: d21d2e8a-fe35-483c-b2b8-4100ed7f0953
+      # -- Option to seed test data provided in a configMap
+      testData:
+        #-- ConfigMap containing json files for the tables to seed, e.g. companies.test.json, addresses.test.json, etc.
+        configMap: "test"
+        #-- Filename identifying the test data files e.g. for companies.test.json the value would be "test"
+        filename: "test"
     logging:
       default: "Information"
   portalmaintenance:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -612,10 +612,10 @@ backend:
       testDataEnvironments: ""
       # -- Option to seed test data provided in a configMap
       testData:
-        #-- ConfigMap containing json files for the tables to seed, e.g. companies.test.json, addresses.test.json, etc.
-        configMap: "test"
-        #-- Filename identifying the test data files e.g. for companies.test.json the value would be "test"
-        filename: "test"
+        # -- ConfigMap containing json files for the tables to seed, e.g. companies.test.json, addresses.test.json, etc.
+        configMap: ""
+        # -- Filename identifying the test data files e.g. for companies.test.json the value would be "test"
+        filename: ""
     logging:
       default: "Information"
   portalmaintenance:


### PR DESCRIPTION
## Description

- enable seeding of test data with configmap

and move default seeding path and processidentity userid out of values file, into job, as changing those values isn't intuitive

## Why

https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/105

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
