### PR TITLE
fix: add usedim wallet env var and improve docs

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -139,6 +139,8 @@ spec:
               value: "{{ .Values.backend.processesworker.bpdm.scope }}"
             - name: "APPLICATIONCHECKLIST__BPDM__USERNAME"
               value: "{{ .Values.backend.placeholder }}"
+            - name: "APPLICATIONCHECKLIST__BPDM__USEDIMWALLET"
+              value: "{{ .Values.backend.useDimWallet }}"
             - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__BASEADDRESS"
               value: "{{ .Values.clearinghouseAddress }}"
             - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__CLIENTID"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -234,6 +234,7 @@ backend:
   portalIntroductionCompanyRolePath: "/companyroles"
   portalIntroductionDataspacePath: "/dataspace"
   userManagementPath: "/usermanagement"
+  # -- Enable for using Decentral Identity Management (DIM) instead of Managed Identity Wallet (MIW) as wallet
   useDimWallet: false
   keycloak:
     # -- Secret containing the database-password and the client-secret for the connection to the centralidp (CX IAM) and the client-secret for the connection to the sharedidp (CX-IAM).


### PR DESCRIPTION
## Description

- fix: add environment variable to use dim in application checklist bpdm
- docs: add install comment to useDimWallet value

## Why

https://github.com/eclipse-tractusx/portal/issues/361

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
