### PR TITLE
fix: set correct path for consent osp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal helm chart.
 
+## unreleased
+
+### Bugfix
+
+* portal-cd:
+  * set correct path for consent osp url
+
 ## 2.1.0-RC1
 
 ### Change
@@ -31,7 +38,6 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
   * removed obsolete centralidp database configuration [#355](https://github.com/eclipse-tractusx/portal/pull/355)
   * changed to directoryApiAddress of bpn did resolver in administration service configuration [#364](https://github.com/eclipse-tractusx/portal/pull/364)
   * increased memory for services service [#359](https://github.com/eclipse-tractusx/portal/pull/359)
-  * set correct value for consent_osp
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ New features, fixed bugs, known defects and other noteworthy changes to each rel
   * removed obsolete centralidp database configuration [#355](https://github.com/eclipse-tractusx/portal/pull/355)
   * changed to directoryApiAddress of bpn did resolver in administration service configuration [#364](https://github.com/eclipse-tractusx/portal/pull/364)
   * increased memory for services service [#359](https://github.com/eclipse-tractusx/portal/pull/359)
+  * set correct value for consent_osp
 
 ## 2.0.0
 

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -448,7 +448,7 @@ dependencies:
 | backend.processesworker.onboardingServiceProvider.encryptionConfigs.index1.paddingMode | string | `"PKCS7"` |  |
 | backend.processesworker.onboardingServiceProvider.encryptionConfigs.index1.encryptionKey | string | `""` | EncryptionKey for onboardingserviceprovider. Secret-key 'onboardingserviceprovider-encryption-key1'. Expected format is 256 bit (64 digits) hex. When upgrading from v2.0.0-RC1 please read document portal-upgrade-details.md |
 | backend.processesworker.networkRegistration.loginDocumentPath | string | `"/documentation/?path=docs%2F09.+Others%28s%29%2F01.+Login.md"` |  |
-| backend.processesworker.networkRegistration.externalRegistrationPath | string | `"/?overlay=consent_osp"` |  |
+| backend.processesworker.networkRegistration.externalRegistrationPath | string | `"/consent_osp"` |  |
 | backend.processesworker.networkRegistration.closeApplicationPath | string | `"/decline"` | The logic to decline an application is not yet implemented in the backend - this will currently lead to a 404 page when clicking on the link in the mail |
 | backend.processesworker.dim.clientId | string | `"dim-client-id"` | Provide dim client-id from CX IAM centralidp. |
 | backend.processesworker.dim.clientSecret | string | `""` | Client-secret for dim client-id. Secret-key 'dim-client-secret'. |

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -860,7 +860,7 @@ backend:
           encryptionKey: ""
     networkRegistration:
       loginDocumentPath: "/documentation/?path=docs%2F09.+Others%28s%29%2F01.+Login.md"
-      externalRegistrationPath: "/?overlay=consent_osp"
+      externalRegistrationPath: "/consent_osp"
       # -- The logic to decline an application is not yet implemented in the backend - this will currently lead to a 404 page when clicking on the link in the mail
       closeApplicationPath: "/decline"
     dim:


### PR DESCRIPTION
## Description

Set correct path for consent osp

## Why

In portal and registration app the consent osp overlay has been moved to a page and the URL path changed.

## Issue

[#907](https://github.com/eclipse-tractusx/portal-frontend/issues/907)

## Checklist

- [x] I have performed a self-review of my changes