### PR TITLE
fix(roles): update role name for approval notifications in appmarketplace

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -500,7 +500,7 @@ backend:
       role1: "Company Admin"
     approveAppUserRoles:
       role0: "Sales Manager"
-      role1: "Service Manager"
+      role1: "App Manager"
     activationUserRoles:
       role0: "Sales Manager"
       role1: "App Manager"


### PR DESCRIPTION
## Description

For appmarketplace, changed approveAppUserRoles role1 to "App Manager".

## Why

Currently Service Manager receives notifications regarding app approval process. App Manager seems to be the appropriate user role to receive this notification.

## Issue

Refs:  #370

## Checklist

- [x] I have performed a self-review of my changes
