### PR TITLE
fix(secrets): remove unused secret

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -90,11 +90,6 @@ spec:
           value: "{{ .Values.backend.administration.basePath }}"
         - name: "DATABASEACCESS__PORTAL__DATABASESCHEMA"
           value: "{{ .Values.backend.dbConnection.schema }}"
-        - name: "KEYCLOAK_CENTRAL_PASSWORD"
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.backend.keycloak.secret }}"
-              key: "central-db-password"
         - name: "APPLICATIONCHECKLIST__BPDM__BASEADDRESS"
           value: "{{ .Values.bpdm.portalGateAddress }}{{ .Values.bpdm.portalGateApiPath }}"
         - name: "APPLICATIONCHECKLIST__BPDM__CLIENTID"

--- a/charts/portal/templates/deployment-backend-notification.yaml
+++ b/charts/portal/templates/deployment-backend-notification.yaml
@@ -79,11 +79,6 @@ spec:
         {{- end }}
         - name: "DATABASEACCESS__PORTAL__DATABASESCHEMA"
           value: "{{ .Values.backend.dbConnection.schema }}"
-        - name: "KEYCLOAK_CENTRAL_PASSWORD"
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Values.backend.keycloak.secret }}"
-              key: "central-db-password"
         - name: "HEALTHCHECKS__0__PATH"
           value: "{{ .Values.backend.healthChecks.startup.path}}"
         {{- if .Values.backend.notification.healthChecks.startup.tags }}


### PR DESCRIPTION
## Description

Remove central-db-password dependency for administration and notification service. This was missed in: https://github.com/eclipse-tractusx/portal/pull/355

## Why

Administration and notification service still expected central-db-password as kubernetes secret.

## Issue

Refs: #382

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes