### PR TITLE
fix: add config values for external service information

### DIFF
--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -254,6 +254,12 @@ spec:
           value: "{{ .Values.centralidp.clients.portal }}"
         - name: "APPMARKETPLACE__COMPANYADMINROLES__0__USERROLENAMES__0"
           value: "{{ .Values.backend.appmarketplace.companyAdminRoles.role0 }}"
+        - name: "APPMARKETPLACE__DECENTRALIDENTITYMANAGEMENTAUTHURL"
+          value: "{{ .Values.decentralIdentityManagementAuthAddress }}"
+        - name: "APPMARKETPLACE__ISSUERDID"
+          value: "{{ .Values.backend.administration.issuerdid }}"
+        - name: "APPMARKETPLACE__BPNDIDRESOLVERURL"
+          value: "{{ .Values.bpnDidResolver.directoryApiAddress }}"
         - name: "HEALTHCHECKS__0__PATH"
           value: "{{ .Values.backend.healthChecks.startup.path}}"
         {{- if .Values.backend.appmarketplace.healthChecks.startup.tags }}


### PR DESCRIPTION
## Description

Add wallet information settings to the marketplace service

## Why

Those values got introduced to be display as provider information

## Issue

Refs: #841

## Corresponding Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/867

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
