### PR TITLE
feat: add imagePullScrets

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -39,7 +39,7 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.backend.administration.image.pullSecrets }}
-      pullSecrets:
+      imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -38,8 +38,8 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.administration.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.backend.administration.image.imagePullSecrets }}
-      imagePullSecrets:
+      {{- with .Values.backend.administration.image.pullSecrets }}
+      pullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.administration.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.backend.administration.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.administration.name }}
         securityContext:

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -40,9 +40,7 @@ spec:
     spec:
       {{- with .Values.backend.administration.image.imagePullSecrets }}
       imagePullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.administration.name }}

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.appmarketplace.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.backend.appmarketplace.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.appmarketplace.name }}
         securityContext:

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -39,7 +39,7 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.backend.appmarketplace.image.pullSecrets }}
-      pullSecrets:
+      imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/portal/templates/deployment-backend-appmarketplace.yaml
+++ b/charts/portal/templates/deployment-backend-appmarketplace.yaml
@@ -38,11 +38,9 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.appmarketplace.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.backend.appmarketplace.image.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+      {{- with .Values.backend.appmarketplace.image.pullSecrets }}
+      pullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.appmarketplace.name }}

--- a/charts/portal/templates/deployment-backend-notification.yaml
+++ b/charts/portal/templates/deployment-backend-notification.yaml
@@ -38,11 +38,9 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.notification.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.backend.notification.image.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+      {{- with .Values.backend.notification.image.pullSecrets }}
+      pullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.notification.name }}

--- a/charts/portal/templates/deployment-backend-notification.yaml
+++ b/charts/portal/templates/deployment-backend-notification.yaml
@@ -39,7 +39,7 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.backend.notification.image.pullSecrets }}
-      pullSecrets:
+      imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/portal/templates/deployment-backend-notification.yaml
+++ b/charts/portal/templates/deployment-backend-notification.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.notification.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.backend.notification.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.notification.name }}
         securityContext:

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -39,7 +39,7 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.backend.registration.image.pullSecrets }}
-      pullSecrets:
+      imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -38,11 +38,9 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.registration.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.backend.registration.image.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+      {{- with .Values.backend.registration.image.pullSecrets }}
+      pullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.registration.name }}

--- a/charts/portal/templates/deployment-backend-registration.yaml
+++ b/charts/portal/templates/deployment-backend-registration.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.registration.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.backend.registration.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.registration.name }}
         securityContext:

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -39,7 +39,7 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.backend.services.image.pullSecrets }}
-      pullSecrets:
+      imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -38,11 +38,9 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.services.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.backend.services.image.imagePullSecrets }}
-      imagePullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+      {{- with .Values.backend.services.image.pullSecrets }}
+      pullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.services.name }}

--- a/charts/portal/templates/deployment-backend-services.yaml
+++ b/charts/portal/templates/deployment-backend-services.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.backend.services.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.backend.services.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.services.name }}
         securityContext:

--- a/charts/portal/templates/deployment-frontend-assets.yaml
+++ b/charts/portal/templates/deployment-frontend-assets.yaml
@@ -39,10 +39,8 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.frontend.assets.image.pullSecrets }}
-      pullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.frontend.assets.name }}

--- a/charts/portal/templates/deployment-frontend-assets.yaml
+++ b/charts/portal/templates/deployment-frontend-assets.yaml
@@ -38,8 +38,8 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.frontend.assets.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.frontend.assets.image.imagePullSecrets }}
-      imagePullSecrets:
+      {{- with .Values.frontend.assets.image.pullSecrets }}
+      pullSecrets:
         {{- range . }}
         - name: {{ .name }}
         {{- end }}

--- a/charts/portal/templates/deployment-frontend-assets.yaml
+++ b/charts/portal/templates/deployment-frontend-assets.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.frontend.assets.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.frontend.assets.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.frontend.assets.name }}
         securityContext:

--- a/charts/portal/templates/deployment-frontend-portal.yaml
+++ b/charts/portal/templates/deployment-frontend-portal.yaml
@@ -39,10 +39,8 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.frontend.portal.image.pullSecrets }}
-      pullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.frontend.portal.name }}

--- a/charts/portal/templates/deployment-frontend-portal.yaml
+++ b/charts/portal/templates/deployment-frontend-portal.yaml
@@ -38,8 +38,8 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.frontend.portal.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.frontend.portal.image.imagePullSecrets }}
-      imagePullSecrets:
+      {{- with .Values.frontend.portal.image.pullSecrets }}
+      pullSecrets:
         {{- range . }}
         - name: {{ .name }}
         {{- end }}

--- a/charts/portal/templates/deployment-frontend-portal.yaml
+++ b/charts/portal/templates/deployment-frontend-portal.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.frontend.portal.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.frontend.portal.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.frontend.portal.name }}
         securityContext:

--- a/charts/portal/templates/deployment-frontend-registration.yaml
+++ b/charts/portal/templates/deployment-frontend-registration.yaml
@@ -39,10 +39,8 @@ spec:
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.frontend.registration.image.pullSecrets }}
-      pullSecrets:
-        {{- range . }}
-        - name: {{ .name }}
-        {{- end }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.frontend.registration.name }}

--- a/charts/portal/templates/deployment-frontend-registration.yaml
+++ b/charts/portal/templates/deployment-frontend-registration.yaml
@@ -38,6 +38,12 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.frontend.registration.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.frontend.registration.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ .name }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.frontend.registration.name }}
         securityContext:

--- a/charts/portal/templates/deployment-frontend-registration.yaml
+++ b/charts/portal/templates/deployment-frontend-registration.yaml
@@ -38,8 +38,8 @@ spec:
         app: {{ include "portal.fullname" . }}-{{ .Values.frontend.registration.name }}
         {{- include "portal.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.frontend.registration.image.imagePullSecrets }}
-      imagePullSecrets:
+      {{- with .Values.frontend.registration.image.pullSecrets }}
+      pullSecrets:
         {{- range . }}
         - name: {{ .name }}
         {{- end }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -129,7 +129,7 @@ frontend:
       portaltag: 37cd674aa1324f0fbd9c7662b5e43fde89e1a748
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -146,7 +146,7 @@ frontend:
       registrationtag: 064a96674c239433e85d2599b17a95c3434e9bb9
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -162,7 +162,7 @@ frontend:
       assetstag: 587cfb232860b5dc221aefc60758dd81c00f53bb
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -300,7 +300,7 @@ backend:
       registrationservicetag: 294eea9b508022239c633dc84022116b1ba3694d
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -351,7 +351,7 @@ backend:
       administrationservicetag: 294eea9b508022239c633dc84022116b1ba3694d
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -471,7 +471,7 @@ backend:
       appmarketplaceservicetag: 294eea9b508022239c633dc84022116b1ba3694d
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -647,7 +647,7 @@ backend:
       notificationservicetag: 294eea9b508022239c633dc84022116b1ba3694d
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -676,7 +676,7 @@ backend:
       servicesservicetag: 294eea9b508022239c633dc84022116b1ba3694d
       pullPolicy: "IfNotPresent"
       # -- Pull secrets for private docker registry
-      imagePullSecrets: []
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -128,6 +128,8 @@ frontend:
       name: "docker.io/tractusx/portal-frontend"
       portaltag: 37cd674aa1324f0fbd9c7662b5e43fde89e1a748
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -143,6 +145,8 @@ frontend:
       name: "docker.io/tractusx/portal-frontend-registration"
       registrationtag: 064a96674c239433e85d2599b17a95c3434e9bb9
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -157,6 +161,8 @@ frontend:
       name: "docker.io/tractusx/portal-assets"
       assetstag: 39ec46dcb883080c5d0ac94984630ec0409929c7
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -293,6 +299,8 @@ backend:
       name: "docker.io/tractusx/portal-registration-service"
       registrationservicetag: d3dd7919c03d815bad3b10e8ddb4c306e549e92a
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -342,6 +350,8 @@ backend:
       name: "docker.io/tractusx/portal-administration-service"
       administrationservicetag: 7825b1be9caf62790002ffc522ba1b1d520db431
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -460,6 +470,8 @@ backend:
       name: "docker.io/tractusx/portal-marketplace-app-service"
       appmarketplaceservicetag: d3dd7919c03d815bad3b10e8ddb4c306e549e92a
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -634,6 +646,8 @@ backend:
       name: "docker.io/tractusx/portal-notification-service"
       notificationservicetag: d3dd7919c03d815bad3b10e8ddb4c306e549e92a
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -661,6 +675,8 @@ backend:
       name: "docker.io/tractusx/portal-services-service"
       servicesservicetag: d3dd7919c03d815bad3b10e8ddb4c306e549e92a
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      imagePullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:


### PR DESCRIPTION
## Description
This work has been done together with @gomezbc

The imagePullSecrets field allows you to specify secrets needed to pull Docker images from private repositories.

## Why

In many organizations, container images are stored in private registries rather than public ones for security and compliance reasons. To pull these images, Kubernetes needs credentials, which are provided via imagePullSecrets. This code dynamically includes the necessary secrets for pulling images, based on the configuration provided in the Helm chart's values file.

## Next Steps
Would it be interesting to add this implementation to other tractus-x charts?

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
