### PR TITLE
feat(sdFactory): add clearinghouseConnectDisabled to config

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -441,6 +441,8 @@ spec:
           value: "{{ .Values.portalAddress }}{{ .Values.backend.portalHelpPath }}"
         - name: "REGISTRATION__USEDIMWALLET"
           value: "{{ .Values.backend.useDimWallet }}"
+        - name: "REGISTRATION__CLEARINGHOUSECONNECTDISABLED"
+          value: "{{ .Values.backend.processesworker.clearinghouseConnectDisabled }}"
         - name: "SERVICEACCOUNT__CLIENTID"
           value: "{{ .Values.backend.administration.serviceAccount.clientId }}"
         - name: "SERVICEACCOUNT__ENCRYPTIONCONFIGINDEX"


### PR DESCRIPTION
## Description

Added config value for clearinghouseConnectDisabled to the registration settings in the administration service

## Why

The backend has added a check for the clearinghouseConnectDisabled in the registration business logic, therefor the value is needed in the configuration

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/837

## Corresponding Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/847

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
