### PR TITLE
chore(localdev): reference portal chart from filesystem and integrate portal v2.1.0

### DIFF
--- a/charts/localdev/Chart.yaml
+++ b/charts/localdev/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: localdev-portal-iam
 type: application
-version: 0.6.1
+version: 0.7.0
 description: Setup of CX Portal & IAM for local development
 home: https://github.com/eclipse-tractusx/portal-cd
 sources:
@@ -32,8 +32,8 @@ sources:
 dependencies:
   - condition: portal.enabled
     name: portal
-    repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.0.0
+    repository: file://../portal
+    version: 2.1.0
   - condition: centralidp.enabled
     name: centralidp
     repository: https://eclipse-tractusx.github.io/charts/dev

--- a/charts/localdev/values.yaml
+++ b/charts/localdev/values.yaml
@@ -177,9 +177,6 @@ portal:
       issuerComponent:
         clientId: "sa-cl2-04"
         clientSecret: "c0gFPfWWUpeOr7MP6DIqdRPhUfaX4GRC"
-        encryptionConfigs:
-          index0:
-            encryptionKey: "39ffab76f99ece1e4ac72f973d5c703737324a75c6445e84fa317a7833476a15"
       bpnDidResolver:
         # -- ApiKey for management endpoint of the bpnDidResolver. Secret-key 'bpndidresolver-api-key'.
         apiKey: ""
@@ -199,6 +196,7 @@ portal:
         encryptionConfigs:
           index0:
             encryptionKey: "d2e27d71b018cb36029184852f1baa3e26891be94718f77de4c7cc6c882fe317"
+      clearinghouseConnectDisabled: false
     mailing:
       host: "smtp.tx.test"
       port: "587"


### PR DESCRIPTION
## Description

- reference portal chart over filesystem
- integrate changes from 2.1.0 portal version

## Why

https://github.com/eclipse-tractusx/portal/issues/399

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
