### PR TITLE
fix: add config for sd document

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -491,6 +491,8 @@ spec:
               value: "{{ .Values.backend.processesworker.mailing.encryptionConfigs.index0.paddingMode }}"
             - name: "APPLICATIONCREATION_USEDIMWALLET"
               value: "{{ .Values.backend.useDimWallet }}"
+            - name: "SELFDESCRIPTIONCREATIONPROCESS__SELFDESCRIPTIONDOCUMENTURL"
+              value: "{{ .Values.portalBackendAddress }}{{ .Values.backend.administration.connectors.selfDescriptionDocumentPath }}"
             ports:
             - name: http
               containerPort: {{ .Values.portContainer }}


### PR DESCRIPTION
## Description

Add config value for the self description documents

## Why

The config is needed for the backend

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/813

## Corresponding Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/938

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
