### PR TITLE
feat: add imagePullSecrets

### DIFF
--- a/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
+++ b/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
@@ -33,6 +33,10 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          {{- with .Values.backend.portalmaintenance.image.pullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           containers:
           - name: {{ include "portal.fullname" . }}-{{ .Values.backend.portalmaintenance.name }}
             securityContext:

--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -34,6 +34,10 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          {{- with .Values.backend.processesworker.image.pullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           containers:
           - name: {{ include "portal.fullname" . }}-{{ .Values.backend.processesworker.name }}
             securityContext:

--- a/charts/portal/templates/job-backend-portal-migrations.yaml
+++ b/charts/portal/templates/job-backend-portal-migrations.yaml
@@ -34,6 +34,10 @@ spec:
       name: {{ include "portal.fullname" . }}-{{ .Values.backend.portalmigrations.name }}
     spec:
       restartPolicy: Never
+      {{- with .Values.backend.portalmigrations.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.portalmigrations.name }}
         securityContext:

--- a/charts/portal/templates/job-backend-provisioning-migrations.yaml
+++ b/charts/portal/templates/job-backend-provisioning-migrations.yaml
@@ -34,6 +34,10 @@ spec:
       name: {{ include "portal.fullname" . }}-{{ .Values.backend.provisioningmigrations.name }}
     spec:
       restartPolicy: Never
+      {{- with .Values.backend.provisioningmigrations.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ include "portal.fullname" . }}-{{ .Values.backend.provisioningmigrations.name }}
         securityContext:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -604,6 +604,8 @@ backend:
       name: "docker.io/tractusx/portal-portal-migrations"
       portalmigrationstag: 8bb3bfd9dc9c45b170516f5a2387e7b443bb8730
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -628,6 +630,8 @@ backend:
       name: "docker.io/tractusx/portal-maintenance-service"
       portalmaintenancetag: b9e89196cf538c76ebe4dc191c6684a017a32140
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -760,6 +764,8 @@ backend:
       name: "docker.io/tractusx/portal-provisioning-migrations"
       provisioningmigrationstag: bea374c345aa236eb6e2112734b8e3004c065647
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:
@@ -776,6 +782,8 @@ backend:
       name: "docker.io/tractusx/portal-processes-worker"
       processesworkertag: 8bb3bfd9dc9c45b170516f5a2387e7b443bb8730
       pullPolicy: "IfNotPresent"
+      # -- Pull secrets for private docker registry
+      pullSecrets: []
     # -- We recommend to review the default resource limits as this should a conscious choice.
     resources:
       requests:


### PR DESCRIPTION
## Description

Enabled more imagepullsecrets to the previous portal PR [clipse-tractusx/portal/pull/396](https://github.com/eclipse-tractusx/portal/pull/396)

## Why

In many organizations, container images are stored in private registries rather than public ones for security and compliance reasons. To pull these images, Kubernetes needs credentials, which are provided via imagePullSecrets. This code dynamically includes the necessary secrets for pulling images, based on the configuration provided in the Helm chart's values file.

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
