### PR TITLE
feat(technicaluser): authServiceUrl value added in administration service

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -464,6 +464,8 @@ spec:
           value: "{{ .Values.backend.administration.serviceAccount.encryptionConfigs.index0.cipherMode }}"
         - name: "SERVICEACCOUNT__ENCRYPTIONCONFIGS__0__PADDINGMODE"
           value: "{{ .Values.backend.administration.serviceAccount.encryptionConfigs.index0.paddingMode }}"
+        - name: "SERVICEACCOUNT__AUTHSERVICEURL"
+          value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.tokenPath }}"
         - name: "SERVICEACCOUNT__DIMCREATIONROLES__0__CLIENTID"
           value: "{{ .Values.centralidp.clients.technicalRolesManagement }}"
         - name: "SERVICEACCOUNT__DIMCREATIONROLES__0__USERROLENAMES__0"


### PR DESCRIPTION
## Description

Need to add authServiceUrl value for internal user type 
GET: api/administration/serviceaccount/owncompany/serviceaccounts/{GetServiceAccountId}

## Why

authServiceUrl added in portal administration service 

## Issue

[#976](https://github.com/eclipse-tractusx/portal-backend/issues/976)

Link to pull request from other repository.

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
