### PR TITLE
chore(int): adjust config for enabled startSharingStateAsReady

### DIFF
--- a/environments/helm-values/values-int.yaml
+++ b/environments/helm-values/values-int.yaml
@@ -236,7 +236,6 @@ backend:
     bpdm:
       clientId: "<path:portal/data/portal-iam-clientIds#bpdm-client-id>"
       clientSecret: "<path:portal/data/int/iam/centralidp-client-secrets#portal-bpdm-sa>"
-      startSharingStateAsReady: false
     clearinghouse:
       clientId: "<path:portal/data/int/clearinghouse#client-id>"
       clientSecret: "<path:portal/data/int/clearinghouse#client-secret>"


### PR DESCRIPTION
## Description

adjust config for enabled startSharingStateAsReady from BPDM side

--> value not needed anymore in environment specific values file as it can default to true which is set in the values.yaml
Please include a summary of the change.

## Why

it was decided that the ready state should be managed from BPDM side

## Issue

n/a
relates to https://github.com/eclipse-tractusx/portal-frontend/issues/1026 and https://github.com/eclipse-tractusx/portal-frontend/issues/955
