### PR TITLE
fix(osp path): update default path value

### DIFF
--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -468,7 +468,7 @@ dependencies:
 | backend.processesworker.onboardingServiceProvider.encryptionConfigs.index1.paddingMode | string | `"PKCS7"` |  |
 | backend.processesworker.onboardingServiceProvider.encryptionConfigs.index1.encryptionKey | string | `""` | EncryptionKey for onboardingserviceprovider. Secret-key 'onboardingserviceprovider-encryption-key1'. Expected format is 256 bit (64 digits) hex. When upgrading from v2.0.0-RC1 please read document portal-upgrade-details.md |
 | backend.processesworker.networkRegistration.loginDocumentPath | string | `"/documentation/?path=docs%2F09.+Others%28s%29%2F01.+Login.md"` |  |
-| backend.processesworker.networkRegistration.externalRegistrationPath | string | `"/consent_osp"` |  |
+| backend.processesworker.networkRegistration.externalRegistrationPath | string | `"/consentOsp"` |  |
 | backend.processesworker.networkRegistration.closeApplicationPath | string | `"/decline"` | The logic to decline an application is not yet implemented in the backend - this will currently lead to a 404 page when clicking on the link in the mail |
 | backend.processesworker.dim.clientId | string | `"dim-client-id"` | Provide dim client-id from CX IAM centralidp. |
 | backend.processesworker.dim.clientSecret | string | `""` | Client-secret for dim client-id. Secret-key 'dim-client-secret'. |

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -896,7 +896,7 @@ backend:
           encryptionKey: ""
     networkRegistration:
       loginDocumentPath: "/documentation/?path=docs%2F09.+Others%28s%29%2F01.+Login.md"
-      externalRegistrationPath: "/consent_osp"
+      externalRegistrationPath: "/consentOsp"
       # -- The logic to decline an application is not yet implemented in the backend - this will currently lead to a 404 page when clicking on the link in the mail
       closeApplicationPath: "/decline"
     dim:


### PR DESCRIPTION
## Description

 update osp path to camelCase to sync it with the portal-front end code

## Why

Some of the pages got renamed portal. Default helm values should be aligned.

## Issue

#439 

Link to pull request from other repository.

## Checklist

Please delete options that are not relevant.

- [ ] I have performed a self-review of my changes
- [ ] I have successfully tested my changes
- [ ] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [ ] I have commented my changes, particularly in hard-to-understand areas
