### PR TITLE
fix(dim): adjust dim configuration to enable other idps

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -232,7 +232,7 @@ spec:
             - name: "APPLICATIONCHECKLIST__DIM__SCOPE"
               value: "{{ .Values.backend.processesworker.dim.scope }}"
             - name: "APPLICATIONCHECKLIST__DIM__TOKENADDRESS"
-              value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.tokenPath }}"
+              value: "{{ .Values.dimWrapper.tokenAddress }}"
             - name: "APPLICATIONCHECKLIST__DIM__BASEADDRESS"
               value: "{{ .Values.dimWrapper.baseAddress }}{{ .Values.dimWrapper.apiPath }}"
             - name: "APPLICATIONCHECKLIST__DIM__UNIVERSALRESOLVERADDRESS"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -83,6 +83,9 @@ dimWrapper:
   baseAddress: "https://dim.example.org"
   # -- Provide the api path
   apiPath: "/api/dim"
+  # -- Provide dim token address.
+  tokenAddress: "https://keycloak.example.org/realms/example/protocol/openid-connect/token"
+
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"
 
 frontend:

--- a/environments/helm-values/values-int.yaml
+++ b/environments/helm-values/values-int.yaml
@@ -36,6 +36,7 @@ issuerComponentAddress: "https://ssi-credential-issuer.int.catena-x.net"
 bpnDidResolverAddress: "http://bdrs-bdrs-server:8081"
 dimWrapper:
   baseAddress: "https://dim.int.catena-x.net"
+  tokenAddress: "https://centralidp.int.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
 decentralIdentityManagementAuthAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap/api/v2.0.0/iatp/catena-x-portal"
 bpnDidResolver:
   managementApiAddress: "http://bdrs-bdrs-server:8081"


### PR DESCRIPTION
## Description

adjusted the configuration for the dim middle layer to be configureable to use other idps than the central idp

## Why

To have the possibility to use another idp than the central idp for the dim middle layer

## Issue

Refs: #373

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
