### PR TITLE
chore(administration): add bpn address for pool access in admin service

### DIFF
--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -286,6 +286,8 @@ spec:
           value: "True"
         - name: "DOCUMENT__FRAMEDOCUMENTTYPEIDS__0"
           value: "{{ .Values.backend.administration.frameDocumentTypeIds.type0 }}"
+        - name: "BPN_ADDRESS"
+          value: "{{ .Values.bpdm.poolAddress }}{{ .Values.bpdm.poolApiPath }}"
         - name: "HEALTHCHECKS__0__PATH"
           value: "{{ .Values.backend.healthChecks.startup.path}}"
         {{- if .Values.backend.administration.healthChecks.startup.tags }}


### PR DESCRIPTION
## Description

Developed an API in portal-backend to get data from partner-network-pool instead of calling business-partner-pool service directly from the portal-frontend.

## Why

This approach will make it consistent and secure, as we are already been calling business-partner-pool service from portal-backed to get legal-entity data by BPN.

## Issue

Ref: #457

## Corresponding Backend PR

https://github.com/eclipse-tractusx/portal-backend/pull/1082

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
