### PR TITLE
chore(BPDM): Set BPDM pool url

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -148,7 +148,7 @@ spec:
             - name: "APPLICATIONCHECKLIST__BPDM__STARTSHARINGSTATEASREADY"
               value: "{{ .Values.backend.processesworker.bpdm.startSharingStateAsReady }}"
             - name: "APPLICATIONCHECKLIST__BPDM__BUSINESSPARTNERPOOLBASEADDRESS"
-              value: "{{ .Values.bpdm.poolAddress }}{{ .Values.bpdm.poolApiPath }}"
+              value: "{{ .Values.bpdm.poolAddress }}"
             - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__BASEADDRESS"
               value: "{{ .Values.clearinghouseAddress }}"
             - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__CLIENTID"

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -118,7 +118,7 @@ spec:
         - name: "APPLICATIONCHECKLIST__BPDM__STARTSHARINGSTATEASREADY"
           value: "{{ .Values.backend.processesworker.bpdm.startSharingStateAsReady }}"
         - name: "APPLICATIONCHECKLIST__BPDM__BUSINESSPARTNERPOOLBASEADDRESS"
-          value: "{{ .Values.bpdm.poolAddress }}{{ .Values.bpdm.poolApiPath }}"
+          value: "{{ .Values.bpdm.poolAddress }}"
         - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__BASEADDRESS"
           value: "{{ .Values.clearinghouseAddress }}"
         - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__CLIENTID"


### PR DESCRIPTION
## Description

Set BPDM pool url to call Business Partner Pool

## Why

Required for: Set Catena-X Membership in BPDM.

## Issue

Ref: #471

https://github.com/eclipse-tractusx/portal-backend/pull/1118

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
