### PR TITLE
feat(bdrs): add custom bpndidresolver token address

### DIFF
--- a/charts/localdev/values.yaml
+++ b/charts/localdev/values.yaml
@@ -182,6 +182,11 @@ portal:
       bpnDidResolver:
         # -- ApiKey for management endpoint of the bpnDidResolver. Secret-key 'bpndidresolver-api-key'.
         apiKey: ""
+        # -- Auth settings of the bpnDidResolver
+        grantType: "client_credentials"
+        clientId: ""
+        clientSecret: ""
+        scope: "openid"
       onboardingServiceProvider:
         encryptionConfigs:
           index0:

--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -295,6 +295,23 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.backend.interfaces.secret }}"
                   key: "bpndidresolver-api-key"
+            - name: "BPNDIDRESOLVER__USERNAME"
+              value: "{{ .Values.backend.placeholder }}"
+            - name: "BPNDIDRESOLVER__PASSWORD"
+              value: "{{ .Values.backend.placeholder }}"
+            - name: "BPNDIDRESOLVER__GRANTTYPE"
+              value: "{{ .Values.backend.processesworker.bpnDidResolver.grantType }}"
+            - name: "BPNDIDRESOLVER__CLIENTID"
+              value: "{{ .Values.backend.processesworker.bpnDidResolver.clientId }}"
+            - name: "BPNDIDRESOLVER__CLIENTSECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.backend.interfaces.secret }}"
+                  key: "bpndidresolver-client-secret"
+            - name: "BPNDIDRESOLVER__SCOPE"
+              value: "{{ .Values.backend.processesworker.bpnDidResolver.scope }}"
+            - name: "BPNDIDRESOLVER__TOKENADDRESS"
+              value: "{{ .Values.centralidp.address }}{{ .Values.backend.keycloak.central.tokenPath }}"
             - name: "KEYCLOAK__CENTRAL__AUTHREALM"
               value: "{{ .Values.centralidp.realm }}"
             - name: "KEYCLOAK__CENTRAL__CLIENTID"

--- a/charts/portal/templates/secret-backend-interfaces.yaml
+++ b/charts/portal/templates/secret-backend-interfaces.yaml
@@ -45,6 +45,7 @@ data:
   issuercomponent-client-secret: {{ coalesce ( .Values.backend.processesworker.issuerComponent.clientSecret | b64enc ) ( index $secret.data "issuercomponent-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
   dim-encryption-key0: {{ coalesce ( .Values.backend.processesworker.dim.encryptionConfigs.index0.encryptionKey | b64enc ) ( index $secret.data "dim-encryption-key0" ) | default ( randAlphaNum 32 ) | quote }}
   bpndidresolver-api-key: {{ coalesce ( .Values.backend.processesworker.bpnDidResolver.apiKey | b64enc ) ( index $secret.data "bpndidresolver-api-key" ) | default ( randAlphaNum 32 ) | quote }}
+  bpndidresolver-client-secret: {{ coalesce ( .Values.backend.processesworker.bpnDidResolver.clientSecret | b64enc ) ( index $secret.data "bpndidresolver-client-secret" ) | default ( randAlphaNum 32 ) | quote }}
   serviceaccount-encryption-key0: {{ coalesce ( .Values.backend.administration.serviceAccount.encryptionConfigs.index0.encryptionKey | b64enc ) ( index $secret.data "serviceaccount-encryption-key0" ) | default ( randAlphaNum 32 ) | quote }}
 {{ else -}}
 stringData:
@@ -62,5 +63,6 @@ stringData:
   issuercomponent-client-secret: {{ .Values.backend.processesworker.issuerComponent.clientSecret | default ( randAlphaNum 32 ) | quote }}
   dim-encryption-key0: {{ .Values.backend.processesworker.dim.encryptionConfigs.index0.encryptionKey | default ( randAlphaNum 32 ) | quote }}
   bpndidresolver-api-key: {{ .Values.backend.processesworker.bpnDidResolver.apiKey | default ( randAlphaNum 32 ) | quote }}
+  bpndidresolver-client-secret: {{ .Values.backend.processesworker.bpnDidResolver.clientSecret | default ( randAlphaNum 32 ) | quote }}
   serviceaccount-encryption-key0: {{ .Values.backend.administration.serviceAccount.encryptionConfigs.index0.encryptionKey | default ( randAlphaNum 32 ) | quote }}
 {{ end }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -961,6 +961,11 @@ backend:
     bpnDidResolver:
       # -- ApiKey for management endpoint of the bpnDidResolver. Secret-key 'bpndidresolver-api-key'.
       apiKey: ""
+      # -- Auth settings of the bpnDidResolver
+      grantType: "client_credentials"
+      clientId: ""
+      clientSecret: ""
+      scope: "openid"
     invitation:
       invitedUserInitialRoles:
         role0: "Company Admin"

--- a/environments/helm-values/values-int.yaml
+++ b/environments/helm-values/values-int.yaml
@@ -272,6 +272,8 @@ backend:
       clientSecret: "<path:portal/data/int/iam/centralidp-client-secrets#portal-issuer-sa>"
     bpnDidResolver:
       apiKey: "<path:portal/data/bdrs-mgmt-api-key#content>"
+      clientId: "<path:portal/data/bdrs-mgmt-client-id#bdrsClientId>"
+      clientSecret: "<path:portal/data/bdrs-mgmt-client-secret#bdrsClientSecret>"
     invitation:
       encryptionConfigs:
         index0:

--- a/environments/helm-values/values-stable.yaml
+++ b/environments/helm-values/values-stable.yaml
@@ -270,6 +270,8 @@ backend:
       clientSecret: "<path:portal/data/stable/iam/centralidp-client-secrets#portal-issuer-sa>"
     bpnDidResolver:
       apiKey: "<path:portal/data/bdrs-mgmt-api-key#content>"
+      clientId: "<path:portal/data/bdrs-mgmt-client-id#bdrsClientId>"
+      clientSecret: "<path:portal/data/bdrs-mgmt-client-secret#bdrsClientSecret>"
     invitation:
       encryptionConfigs:
         index0:


### PR DESCRIPTION
## Description

Add environment variables for bdrs token configuration.

## Why

Client id and secret are more secure than API keys.

## Issue

Ref: #456

## Corresponding Backend PR
https://github.com/eclipse-tractusx/portal-backend/pull/1129

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
