### PR TITLE
docs: fix how to contribute link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## How To Contribute
 
-For more practical information, please refer to [Contribution details](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md).
+For more practical information, please refer to [Contribution details](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md).
 
 ## Contact
 


### PR DESCRIPTION
## Description

Fix the "How to Contribute" link.

## Why

The existing link is broken.

## Issue

[Issue #483](https://github.com/eclipse-tractusx/portal/issues/483) 

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my changes
