### PR TITLE
chore(values): remove sdfactoryIssuerBpn

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -218,8 +218,6 @@ spec:
               value: "{{ .Values.backend.placeholder }}"
             - name: "APPLICATIONCHECKLIST__SDFACTORY__SCOPE"
               value: "{{ .Values.backend.processesworker.sdfactory.scope }}"
-            - name: "APPLICATIONCHECKLIST__SDFACTORY__SDFACTORYISSUERBPN"
-              value: "{{ .Values.operator.bpn }}"
             - name: "APPLICATIONCHECKLIST__SDFACTORY__SDFACTORYURL"
               value: "{{ .Values.sdfactoryAddress }}{{ .Values.backend.processesworker.sdfactory.selfdescriptionPath }}"
             - name: "APPLICATIONCHECKLIST__SDFACTORY__USERNAME"

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -180,8 +180,6 @@ spec:
           value: "{{ .Values.backend.placeholder }}"
         - name: "APPLICATIONCHECKLIST__SDFACTORY__SCOPE"
           value: "{{ .Values.backend.processesworker.sdfactory.scope }}"
-        - name: "APPLICATIONCHECKLIST__SDFACTORY__SDFACTORYISSUERBPN"
-          value: "{{ .Values.operator.bpn }}"
         - name: "APPLICATIONCHECKLIST__SDFACTORY__SDFACTORYURL"
           value: "{{ .Values.sdfactoryAddress }}{{ .Values.backend.processesworker.sdfactory.selfdescriptionPath }}"
         - name: "APPLICATIONCHECKLIST__SDFACTORY__CLEARINGHOUSECONNECTDISABLED"


### PR DESCRIPTION
## Description

sdfactoryIssuerBpn is removed from sdFactory-settings

## Why

with merge of PR https://github.com/eclipse-tractusx/portal-backend/pull/1290 this setting is obsolete.

## Issue

https://github.com/eclipse-tractusx/portal-backend/issues/1288

Link to PR in other repository:
https://github.com/eclipse-tractusx/portal-backend/pull/1290

## Checklist

Please delete options that are not relevant.

- [X] I have performed a self-review of my changes
- [ ] I have successfully tested my changes