### PR TITLE
fix(registration): bpdm pool address for membership activation

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -156,7 +156,7 @@ spec:
             - name: "APPLICATIONCHECKLIST__BPDM__STARTSHARINGSTATEASREADY"
               value: "{{ .Values.backend.processesworker.bpdm.startSharingStateAsReady }}"
             - name: "APPLICATIONCHECKLIST__BPDM__BUSINESSPARTNERPOOLBASEADDRESS"
-              value: "{{ .Values.bpdm.poolAddress }}"
+              value: "{{ .Values.bpdm.poolAddress }}{{ .Values.bpdm.poolApiPath }}"
             - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__BASEADDRESS"
               value: "{{ .Values.clearinghouseAddress }}"
             - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__CLIENTID"

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -118,7 +118,7 @@ spec:
         - name: "APPLICATIONCHECKLIST__BPDM__STARTSHARINGSTATEASREADY"
           value: "{{ .Values.backend.processesworker.bpdm.startSharingStateAsReady }}"
         - name: "APPLICATIONCHECKLIST__BPDM__BUSINESSPARTNERPOOLBASEADDRESS"
-          value: "{{ .Values.bpdm.poolAddress }}"
+          value: "{{ .Values.bpdm.poolAddress }}{{ .Values.bpdm.poolApiPath }}"
         - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__BASEADDRESS"
           value: "{{ .Values.clearinghouseAddress }}"
         - name: "APPLICATIONCHECKLIST__CLEARINGHOUSE__CLIENTID"


### PR DESCRIPTION
## Description

Use configurable poolApiPath in BPDM pool address for application activation.

## Why

Hardcoded path in portal backend does not follow intended behavior if Pool address is using any additional pathing [other than v6](https://github.com/eclipse-tractusx/portal/blob/ef675d0db0eb29e1e54ad3a6ecda2daec1df126e/charts/portal/values.yaml#L51).

## Issue

Refs: eclipse-tractusx/portal-backend#1299

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
