### PR TITLE
feat: Add connectorAllowSdDocumentSkipErrorCode to backend configurations

### DIFF
--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -224,6 +224,8 @@ spec:
               value: "{{ .Values.backend.placeholder }}"
             - name: "APPLICATIONCHECKLIST__SDFACTORY__CLEARINGHOUSECONNECTDISABLED"
               value: "{{ .Values.clearinghouseConnectDisabled }}"
+            - name: "APPLICATIONCHECKLIST__SDFACTORY__CONNECTORALLOWSDDOCUMENTSKIPERRORCODE"
+              value: "{{ .Values.clearinghouseConnectorAllowSdDocumentSkipErrorCode }}"
             - name: "APPLICATIONCHECKLIST__DIM__USERNAME"
               value: "{{ .Values.backend.placeholder }}"
             - name: "APPLICATIONCHECKLIST__DIM__PASSWORD"

--- a/charts/portal/templates/deployment-backend-administration.yaml
+++ b/charts/portal/templates/deployment-backend-administration.yaml
@@ -184,6 +184,8 @@ spec:
           value: "{{ .Values.sdfactoryAddress }}{{ .Values.backend.processesworker.sdfactory.selfdescriptionPath }}"
         - name: "APPLICATIONCHECKLIST__SDFACTORY__CLEARINGHOUSECONNECTDISABLED"
           value: "{{ .Values.clearinghouseConnectDisabled }}"
+        - name: "APPLICATIONCHECKLIST__SDFACTORY__CONNECTORALLOWSDDOCUMENTSKIPERRORCODE"
+          value: "{{ .Values.clearinghouseConnectorAllowSdDocumentSkipErrorCode }}"
         - name: "APPLICATIONCHECKLIST__SDFACTORY__USERNAME"
           value: "{{ .Values.backend.placeholder }}"
         - name: "APPLICATIONCHECKLIST__DIM__USERNAME"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -66,6 +66,8 @@ clearinghouseAddress: "https://validation.example.org"
 clearinghouseTokenAddress: "https://keycloak.example.org/realms/example/protocol/openid-connect/token"
 # -- if set to true the self description document creation will be skipped for company registrations as well as connector registrations
 clearinghouseConnectDisabled: false
+# -- if error code is set, the sd document creation will be skipped if clearing house is sending failure including this error code in the response
+clearinghouseConnectorAllowSdDocumentSkipErrorCode: "E2010"
 
 # -- Provide issuer component base address
 issuerComponentAddress: "https://ssi-credential-issuer.example.org"


### PR DESCRIPTION
## Description

Add configuration for expected error code from clearing house.

## Why

Error code sent by clearing house. Allows connector document creation to be skipped when receiving this error code.

## Issue

Refs: eclipse-tractusx/portal-backend#1301

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
