### PR TITLE
fix: fix Image Pull Secret Indentation for Cronjobs

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: portal
 type: application
-version: 2.4.1
-appVersion: 2.4.1
+version: 2.4.0
+appVersion: 2.4.0
 description: Helm chart for Catena-X Portal
 home: https://github.com/eclipse-tractusx/portal
 sources:

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: portal
 type: application
-version: 2.4.0
-appVersion: 2.4.0
+version: 2.4.1
+appVersion: 2.4.1
 description: Helm chart for Catena-X Portal
 home: https://github.com/eclipse-tractusx/portal
 sources:

--- a/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
+++ b/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
@@ -35,7 +35,7 @@ spec:
           restartPolicy: OnFailure
           {{- with .Values.backend.portalmaintenance.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
           - name: {{ include "portal.fullname" . }}-{{ .Values.backend.portalmaintenance.name }}

--- a/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
+++ b/charts/portal/templates/cronjob-backend-portal-maintenance.yaml
@@ -35,7 +35,7 @@ spec:
           restartPolicy: OnFailure
           {{- with .Values.backend.portalmaintenance.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           containers:
           - name: {{ include "portal.fullname" . }}-{{ .Values.backend.portalmaintenance.name }}

--- a/charts/portal/templates/cronjob-backend-processes.yaml
+++ b/charts/portal/templates/cronjob-backend-processes.yaml
@@ -36,7 +36,7 @@ spec:
           restartPolicy: OnFailure
           {{- with .Values.backend.processesworker.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
           - name: {{ include "portal.fullname" . }}-{{ .Values.backend.processesworker.name }}


### PR DESCRIPTION
## Description & Why

For the imagePullSecrets in the cronjob type template, the indentation needs to be two more spaces due to the fact that it has "one more father" than the Deployments or Jobs templates.

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
- [x] I have added comments in the default values.yaml file with helm-docs syntax ('# -- ') if relevant for installation
- [x] I have commented my changes, particularly in hard-to-understand areas
