### PR TITLE
chore(deployment): change frontend ingress pathType

### DIFF
--- a/environments/helm-values/values-int.yaml
+++ b/environments/helm-values/values-int.yaml
@@ -61,17 +61,17 @@ frontend:
       - host: "portal.int.catena-x.net"
         paths:
           - path: "/(.*)"
-            pathType: "Prefix"
+            pathType: "ImplementationSpecific"
             backend:
               service: "portal"
               port: 8080
           - path: "/registration/(.*)"
-            pathType: "Prefix"
+            pathType: "ImplementationSpecific"
             backend:
               service: "registration"
               port: 8080
           - path: "/((assets|documentation)/.*)"
-            pathType: "Prefix"
+            pathType: "ImplementationSpecific"
             backend:
               service: "assets"
               port: 8080

--- a/environments/helm-values/values-stable.yaml
+++ b/environments/helm-values/values-stable.yaml
@@ -61,17 +61,17 @@ frontend:
       - host: "portal.stable.catena-x.net"
         paths:
           - path: "/(.*)"
-            pathType: "Prefix"
+            pathType: "ImplementationSpecific"
             backend:
               service: "portal"
               port: 8080
           - path: "/registration/(.*)"
-            pathType: "Prefix"
+            pathType: "ImplementationSpecific"
             backend:
               service: "registration"
               port: 8080
           - path: "/((assets|documentation)/.*)"
-            pathType: "Prefix"
+            pathType: "ImplementationSpecific"
             backend:
               service: "assets"
               port: 8080


### PR DESCRIPTION
## Description

Change frontend ingress pathType to ImplementationSpecific for INT and STABLE environments. Same is already in use for umbrella and localdev.

## Why

Strictness of nginx ingress controller requires changes to allow deployment.

## Issue

n/a

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
