### PR TITLE
chore(memory): increase memory for administration service

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -421,10 +421,10 @@ backend:
     resources:
       requests:
         cpu: 75m
-        memory: 600M
+        memory: 650M
       limits:
         cpu: 225m
-        memory: 600M
+        memory: 650M
     basePath: "api/administration"
     logging:
       businessLogic: "Information"


### PR DESCRIPTION
## Description

Increase memory requests and limit for administration service
- requests: 600M -> 650M
- limits: 600M -> 650M

## Why

Startup for administration service does not have enough memory.

## Issue

https://github.com/eclipse-tractusx/portal/issues/541

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
