### PR TITLE
chore: increase memory requests and limits for processes worker

### DIFF
--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -868,10 +868,10 @@ backend:
     resources:
       requests:
         cpu: 75m
-        memory: 600M
+        memory: 700M
       limits:
         cpu: 225m
-        memory: 600M
+        memory: 700M
     logging:
       default: "Information"
       processesLibrary: "Information"


### PR DESCRIPTION
## Description

requests: 600M -> 700M
limits: 600M -> 700M

## Why

Job runs out of memory

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have successfully tested my changes
